### PR TITLE
#20 Fix integer overflow by using Long over Integer

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Include the following dependency in your POM:
 <dependency>
     <groupId>com.lukaspradel</groupId>
     <artifactId>steam-web-api</artifactId>
-    <version>1.4.2</version>
+    <version>1.5.0</version>
 </dependency>
 ```
 
@@ -51,7 +51,7 @@ Furthermore, you need to ensure that the .jar is present at runtime. This depend
 
 ### Manual
 
-You can download the artifact manually from [Sonatype Nexus](https://oss.sonatype.org/service/local/repositories/releases/content/com/lukaspradel/steam-web-api/1.4.2/steam-web-api-1.4.2.jar) or [Maven Central](https://repo1.maven.org/maven2/com/lukaspradel/steam-web-api/1.4.2/steam-web-api-1.4.2.jar).
+You can download the artifact manually from [Sonatype Nexus](https://oss.sonatype.org/service/local/repositories/releases/content/com/lukaspradel/steam-web-api/1.5.0/steam-web-api-1.5.0.jar) or [Maven Central](https://repo1.maven.org/maven2/com/lukaspradel/steam-web-api/1.5.0/steam-web-api-1.5.0.jar).
 
 ### Dependencies
 
@@ -193,6 +193,7 @@ mvn clean deploy -P release
 
 ## History
 
+- Version 1.5.0: Breaking change in this library: use Long return values over Integer to fix [#20](https://github.com/lpradel/steam-web-api-java/issues/20) and avoid possible integer overflows
 - Version 1.4.2: Update dependencies
 - Version 1.4.1: Update httpclient5, Jackson and Slf4j (fix CVE). Remove commons-io dependency.
 - Version 1.4: Upgrade to httpclient5 and change Java version to 8 for broader compatibility and Android support

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.lukaspradel</groupId>
     <artifactId>steam-web-api</artifactId>
-    <version>1.4.3-SNAPSHOT</version>
+    <version>1.5.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Steam Web API</name>
     <description>A library to provide access to the data available from Valve's Steam API</description>
@@ -168,6 +168,7 @@
                     <annotationStyle>jackson2</annotationStyle>
                     <generateBuilders>true</generateBuilders>
                     <initializeCollections>true</initializeCollections>
+                    <useLongIntegers>true</useLongIntegers>
                 </configuration>
                 <executions>
                     <execution>

--- a/src/test/java/com/lukaspradel/steamapi/webapi/client/SteamWebApiClientTest.java
+++ b/src/test/java/com/lukaspradel/steamapi/webapi/client/SteamWebApiClientTest.java
@@ -166,7 +166,7 @@ public class SteamWebApiClientTest extends BaseTest {
 		assertTrue(getNewsForApp.getAdditionalProperties().isEmpty());
 		assertNotNull(getNewsForApp.getAppnews());
 		assertEquals(getNewsForApp.getAppnews().getAppid(),
-				Integer.valueOf(440));
+				Long.valueOf(440));
 		assertEquals(getNewsForApp.getAppnews().getNewsitems().size(), 3);
 	}
 
@@ -225,7 +225,7 @@ public class SteamWebApiClientTest extends BaseTest {
 		assertTrue(getGlobalStatsForGame.getAdditionalProperties().isEmpty());
 		assertNotNull(getGlobalStatsForGame.getResponse());
 		assertEquals(getGlobalStatsForGame.getResponse().getResult(),
-				Integer.valueOf(count));
+				Long.valueOf(count));
 		assertNotNull(getGlobalStatsForGame.getResponse().getGlobalstats());
 
 		assertFalse(getGlobalStatsForGame.getResponse().getGlobalstats()
@@ -295,7 +295,7 @@ public class SteamWebApiClientTest extends BaseTest {
 		assertEquals(getFriendList.getFriendslist().getFriends().get(5)
 				.getRelationship(), Relationship.FRIEND.toString());
 		assertEquals(getFriendList.getFriendslist().getFriends().get(5)
-				.getFriendSince(), Integer.valueOf(1251433222));
+				.getFriendSince(), Long.valueOf(1251433222));
 	}
 
 	@Test
@@ -328,7 +328,7 @@ public class SteamWebApiClientTest extends BaseTest {
 		assertEquals(getPlayerAchievements.getPlayerstats().getAchievements()
 				.get(1).getApiname(), "TF_PLAY_GAME_EVERYMAP");
 		assertEquals(getPlayerAchievements.getPlayerstats().getAchievements()
-				.get(1).getAchieved(), Integer.valueOf(1));
+				.get(1).getAchieved(), Long.valueOf(1));
 	}
 
 	@Test
@@ -360,7 +360,7 @@ public class SteamWebApiClientTest extends BaseTest {
 		assertEquals(getUserStatsForGame.getPlayerstats().getStats().get(2)
 				.getName(), "Scout.accum.iDominations");
 		assertEquals(getUserStatsForGame.getPlayerstats().getStats().get(2)
-				.getValue(), Integer.valueOf(68));
+				.getValue(), Long.valueOf(68));
 
 		assertNotNull(getUserStatsForGame.getPlayerstats().getAchievements());
 		assertEquals(getUserStatsForGame.getPlayerstats().getAchievements()
@@ -368,7 +368,7 @@ public class SteamWebApiClientTest extends BaseTest {
 		assertEquals(getUserStatsForGame.getPlayerstats().getAchievements()
 				.get(1).getName(), "TF_PLAY_GAME_EVERYMAP");
 		assertEquals(getUserStatsForGame.getPlayerstats().getAchievements()
-				.get(1).getAchieved(), Integer.valueOf(1));
+				.get(1).getAchieved(), Long.valueOf(1));
 	}
 
 	@Test
@@ -390,16 +390,16 @@ public class SteamWebApiClientTest extends BaseTest {
 		assertTrue(getOwnedGames.getAdditionalProperties().isEmpty());
 		assertNotNull(getOwnedGames.getResponse());
 		assertEquals(getOwnedGames.getResponse().getGameCount(),
-				Integer.valueOf(487));
+				Long.valueOf(487));
 		assertNotNull(getOwnedGames.getResponse().getGames());
 		assertEquals(getOwnedGames.getResponse().getGames().size(), 487);
 
 		assertEquals(getOwnedGames.getResponse().getGames().get(0).getAppid(),
-				Integer.valueOf(10));
+				Long.valueOf(10));
 		assertEquals(getOwnedGames.getResponse().getGames().get(0).getName(),
 				"Counter-Strike");
 		assertEquals(getOwnedGames.getResponse().getGames().get(0)
-				.getPlaytimeForever(), Integer.valueOf(32));
+				.getPlaytimeForever(), Long.valueOf(32));
 		assertEquals(getOwnedGames.getResponse().getGames().get(0)
 				.getImgIconUrl(), "6b0312cda02f5f777efa2f3318c307ff9acafbb5");
 		assertEquals(getOwnedGames.getResponse().getGames().get(0)
@@ -429,18 +429,18 @@ public class SteamWebApiClientTest extends BaseTest {
 		assertTrue(getRecentlyPlayedGames.getAdditionalProperties().isEmpty());
 		assertNotNull(getRecentlyPlayedGames.getResponse());
 		assertEquals(getRecentlyPlayedGames.getResponse().getTotalCount(),
-				Integer.valueOf(6));
+				Long.valueOf(6));
 		assertNotNull(getRecentlyPlayedGames.getResponse().getGames());
 		assertEquals(getRecentlyPlayedGames.getResponse().getGames().size(), 3);
 
 		assertEquals(getRecentlyPlayedGames.getResponse().getGames().get(0)
-				.getAppid(), Integer.valueOf(271590));
+				.getAppid(), Long.valueOf(271590));
 		assertEquals(getRecentlyPlayedGames.getResponse().getGames().get(0)
 				.getName(), "Grand Theft Auto V");
 		assertEquals(getRecentlyPlayedGames.getResponse().getGames().get(0)
-				.getPlaytime2weeks(), Integer.valueOf(190));
+				.getPlaytime2weeks(), Long.valueOf(190));
 		assertEquals(getRecentlyPlayedGames.getResponse().getGames().get(0)
-				.getPlaytimeForever(), Integer.valueOf(190));
+				.getPlaytimeForever(), Long.valueOf(190));
 		assertEquals(getRecentlyPlayedGames.getResponse().getGames().get(0)
 				.getImgIconUrl(), "1e72f87eb927fa1485e68aefaff23c7fd7178251");
 		assertEquals(getRecentlyPlayedGames.getResponse().getGames().get(0)
@@ -501,11 +501,11 @@ public class SteamWebApiClientTest extends BaseTest {
 		assertEquals(getSchemaForGame.getGame().getAvailableGameStats()
 				.getAchievements().get(0).getName(), "hot_wheels");
 		assertEquals(getSchemaForGame.getGame().getAvailableGameStats()
-				.getAchievements().get(0).getDefaultvalue(), Integer.valueOf(0));
+				.getAchievements().get(0).getDefaultvalue(), Long.valueOf(0));
 		assertEquals(getSchemaForGame.getGame().getAvailableGameStats()
 				.getAchievements().get(0).getDisplayName(), "Coming in Hot");
 		assertEquals(getSchemaForGame.getGame().getAvailableGameStats()
-				.getAchievements().get(0).getHidden(), Integer.valueOf(0));
+				.getAchievements().get(0).getHidden(), Long.valueOf(0));
 		assertEquals(
 				getSchemaForGame.getGame().getAvailableGameStats()
 						.getAchievements().get(0).getDescription(),
@@ -554,9 +554,9 @@ public class SteamWebApiClientTest extends BaseTest {
 		assertEquals(getPlayerBans.getPlayers().get(0).getVACBanned(),
 				Boolean.FALSE);
 		assertEquals(getPlayerBans.getPlayers().get(0).getNumberOfVACBans(),
-				Integer.valueOf(0));
+				Long.valueOf(0));
 		assertEquals(getPlayerBans.getPlayers().get(0).getDaysSinceLastBan(),
-				Integer.valueOf(0));
+				Long.valueOf(0));
 		assertEquals(getPlayerBans.getPlayers().get(0).getEconomyBan(), "none");
 	}
 
@@ -639,8 +639,8 @@ public class SteamWebApiClientTest extends BaseTest {
 		assertNotNull(getHeroes.getResult());
 
 		assertNotNull(getHeroes.getResult().getStatus());
-		assertEquals(getHeroes.getResult().getStatus(), Integer.valueOf(200));
-		assertEquals(getHeroes.getResult().getCount(),Integer.valueOf(111));
+		assertEquals(getHeroes.getResult().getStatus(), Long.valueOf(200));
+		assertEquals(getHeroes.getResult().getCount(),Long.valueOf(111));
 		assertEquals(getHeroes.getResult().getHeroes().size(),111);
 		assertNotNull(getHeroes.getResult().getHeroes().get(0).getId());
 		assertNotNull(getHeroes.getResult().getHeroes().get(0).getName());
@@ -686,7 +686,7 @@ public class SteamWebApiClientTest extends BaseTest {
 		assertNotNull(getLiveLeagueGames);
 		assertTrue(getLiveLeagueGames.getAdditionalProperties().isEmpty());
 		assertNotNull(getLiveLeagueGames.getResult());
-		assertEquals(getLiveLeagueGames.getResult().getStatus(),Integer.valueOf(200));
+		assertEquals(getLiveLeagueGames.getResult().getStatus(),Long.valueOf(200));
 		assertFalse(getLiveLeagueGames.getResult().getGames().isEmpty());
 		assertNotNull(getLiveLeagueGames.getResult().getGames().get(0).getLobbyId());
 		assertNotNull(getLiveLeagueGames.getResult().getGames().get(0).getMatchId());

--- a/src/test/resources/com/lukaspradel/steamapi/webapi/client/GetUserStatsForGame.json
+++ b/src/test/resources/com/lukaspradel/steamapi/webapi/client/GetUserStatsForGame.json
@@ -5,7 +5,7 @@
         "stats": [
             {
                 "name": "Scout.accum.iBuildingsDestroyed",
-                "value": 123
+                "value": 4294967260
             },
             {
                 "name": "Scout.accum.iDamageDealt",


### PR DESCRIPTION
Fixes #20 by using Long over Integer for all JSON Schema 'integer' types. This error could occur e.g. for 'value' field of 'Stat' class in GetUserStatsForGame API