### PR TITLE
Revert "Bump jakarta.xml.bind:jakarta.xml.bind-api from 2.3.3 to 4.0.2"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 
         <!-- Dependencies versions -->
         <jackson.version>2.18.2</jackson.version>
-        <jaxb-api.version>4.0.2</jaxb-api.version>
+        <jaxb-api.version>2.3.3</jaxb-api.version>
 
         <!-- Test dependencies versions -->
         <testng.version>7.10.2</testng.version>


### PR DESCRIPTION
Reverts lpradel/steam-web-api-java#36

This broke the coveralls mvn plugin => will have to switch to coveralls GH action